### PR TITLE
Adding a plugin to format page names with title casing:

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - run: pip install mkdocs-material mkdocs-redirects
+      - run: pip install mkdocs-material mkdocs-redirects mkdocs-title-casing-plugin
       - run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,4 +20,5 @@ plugins:
       lang: en
   - tags:
       tags_file: tags.md
-
+  - title-casing:
+      capitalization_type: title


### PR DESCRIPTION
 - Current: "Google chrome"
 - After: "Google Chrome"