### PR TITLE
Updated Mandiant page

### DIFF
--- a/docs/mandiant.md
+++ b/docs/mandiant.md
@@ -1,14 +1,35 @@
 ---
 tags:
   -  Organization
-  -  Articles that need to be expanded
+  -  Incident Response
+  -  Threat Intelligence
 ---
-## List of Mandiant Products
 
-- [First Response](first_response.md) - An agent based [incident
-  response](incident_response.md) tool.
-- [Red Curtain](red_curtain.md)
-- [Web Historian](web_historian.md)
+# Mandiant
+
+Mandiant is a US-based cybersecurity company that was acquired by Google Cloud in 2022. Mandiant was originally founded as Red Cliff Consulting in 2004 before rebranding in 2006. Mandiant gained significant fame in February 2013 when it released the [APT1 report](https://www.mandiant.com/resources/apt1-exposing-one-of-chinas-cyber-espionage-units), a report detailing and implicating China's efforts, specifically China's 2nd Bureau of the People's Liberation Army (PLA) General Staff Department's (GSD) 3rd Department (Military Cover Designator 61398), in cyber espionage.
+
+In December 2013, Mandiant was acquired by FireEye, and the combined company offered incident response, consulting, and proactive services, managed detection and response (MDR), and various cybersecurity products. The FireEye name and product line were sold to Symphony Technology Group in June 2021.
+
+In March 2022, Google announced its plans to acquire Mandiant and integrate it in Google Cloud. The acquisition was completed in September 2022. The Mandiant brand will be retained as a part of Google Cloud.
+
+Since its inception, Mandiant has significant contributions to the DFIR community, including (but not limited to):
+
+- Discovery and release of new forensic artifacts.
+- Disclosure of threat intelligence reports and threat actor TTPs.
+- Release and maintenance of free, open or closed source tools.
+
+## List of Mandiant Tools
+
+|Product Name|Description|Version|Status|Link|
+|-|-|-|-|-|
+|capa|Open source tool to identify capabilities within an executable file|4.0.1|Active|[Link](https://github.com/mandiant/capa)|
+|Commando-VM|A Windows-based security distribution for penetration testing and red teaming|N/A|Active|[Link](https://github.com/mandiant/commando-vm)|
+|First Response|An agent-based incident response tool.|N/A|Deprecated|N/A|
+|Flare-VM|A Windows-based security distribution for malware analysis, incident response, and other cybersecurity activities|3.0.1|Active|[Link](https://github.com/mandiant/flare-vm)
+|Floss (Flare Obfuscated String Solver)|A tool to automatically extract obfuscated strings from malware|2.1.0|Active|[Link](https://github.com/mandiant/flare-floss)|
+|Red Curtain|Originally released at BlackHat Federal in 2007, this tool was described as a malware detection product|N/A|Deprecated|N/A|
+|Web Historian|A free tool to parse web browser history from FireFox 2/3+, Chrome 3+, and Internet Explorer versions 5 through 8|2.0|Active|[Link](https://www.mandiant.com/resources/blog/web-historian-reloaded)|
 
 ## External Links
 


### PR DESCRIPTION
This was a simple and easy add - trying to knock out pages as I can :) Also included on the new page is a table of Mandiant tools, kept up to date. Redline went to the FireEye folks and thus didn't get included. However, it should get its own page (on the horizon). 

I'll be creating and/or updating separate pages for each tool, as appropriate, for Wiki purposes.