### PR TITLE
Removed outdated Webtracer related articles

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -602,14 +602,6 @@ can run 'headless', i.e. everything in background.
 
 <!-- -->
 
-Webtracer
-<http://www.forensictracer.com>
-
-Software for forensic analysis of internet resources (IP address, e-mail
-address, domain name, URL, e-mail headers, log files...)
-
-<!-- -->
-
 Recon for MAC OS X
 <https://www.sumuri.com/products/recon/>
 

--- a/docs/webtracer.md
+++ b/docs/webtracer.md
@@ -1,7 +1,0 @@
----
-tags:
-  -  Articles that need to be expanded
----
-## External Links
-
-- [Official website](http://www.forensictracer.com/)


### PR DESCRIPTION
For reviewer link to www.forensictracer.com is dead and based on a quick websearch no clear new home for Webtracer