### PR TITLE
docs: update information about headers sent by "The BAT!" MUA

### DIFF
--- a/docs/the_bat_header_format.md
+++ b/docs/the_bat_header_format.md
@@ -5,11 +5,9 @@ tags:
 ---
 The Bat! v3
 
-    Date: Mon, 6 Aug 2007 00:41:44 +0200
+    Date: Fri, 7 Feb 2025 15:23:52 +0300
     From: Username <username@sendinghost.com>
-    X-Mailer: The Bat! (v3.95.8) Professional
-    X-Priority: 3 (Normal)
-    Message-ID: <1398886086.20070806004144@sendinghost.com>
+    Message-ID: <1066947962.20250207152352@gmail.com>
     To: Username <username@receivinghost.com>
     Subject: header test. the bat
     MIME-Version: 1.0
@@ -17,7 +15,6 @@ The Bat! v3
     Content-Transfer-Encoding: 7bit
     Content-Type: multipart/mixed; boundary="----------069134143049E2085"
 
-    
 Message-ID format:
 
 `Message-ID` consists of 4 parts

--- a/docs/the_bat_header_format.md
+++ b/docs/the_bat_header_format.md
@@ -15,7 +15,21 @@ The Bat! v3
     MIME-Version: 1.0
     Content-Type: text/plain; charset=us-ascii
     Content-Transfer-Encoding: 7bit
+    Content-Type: multipart/mixed; boundary="----------069134143049E2085"
 
+    
+Message-ID format:
+
+`Message-ID` consists of 4 parts
+
+* A random string of numbers
+* A timestamp of the format YYYYmmDDHHMMSS
+* The `@` symbol
+* The domain of the sending host
+
+As at March 2025, there is [an interesting nuance](https://www.bentasker.co.uk/posts/blog/security/seducing-a-romance-scammer.html#scheduled-sending) in `Message-ID` when used with the mail agent's [Postponed Sending](https://www.ritlabs.com/en/products/thebat/postponed.php) feature. When a mail's sending is postponed, the `Date` header will be updated accordingly, but the timestamp within the Message ID _will not_.
+
+    
 ## External Links
 
 ## Tools


### PR DESCRIPTION
This adds information about

* The format used for boundary markers
* Additional information about the `Message-ID`

