### PR TITLE
Improve historical context in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Forensics Wiki on GitHub
 
-The Forensics Wiki is an open source website providing information related to digital forensics. The articles in the wiki cover a wide range of information from [tools used during investigations](https://forensics.wiki/tags/#tools) to [papers](https://forensics.wiki/tags/#papers), [people](https://forensics.wiki/tags/#people), and [organizations](https://forensics.wiki/tags/#organization) that contribute to the field.
+[The Forensics Wiki](https://forensics.wiki/) is an open source website providing information related to digital forensics. The articles in the wiki cover a wide range of information from [tools used during investigations](https://forensics.wiki/tags/#tools) to [papers](https://forensics.wiki/tags/#papers), [people](https://forensics.wiki/tags/#people), and [organizations](https://forensics.wiki/tags/#organization) that contribute to the field.
 
-The Forensics Wiki has transitioned to a new domain and platform; read more about it at [Transitioning Forensics Wiki to GitHub](https://osdfir.blogspot.com/2022/11/transitioning-forensics-wiki-to-github.html). You can view the new site at [https://forensics.wiki/](https://forensics.wiki/).
+The Forensics Wiki (previously hosted at `forensicswiki.{org,com,xyz}`) was transitioned to this repo from 2019-2022. Learn more at [Transitioning Forensics Wiki to GitHub](https://osdfir.blogspot.com/2022/11/transitioning-forensics-wiki-to-github.html). The wiki is now hosted at [https://forensics.wiki/](https://forensics.wiki/).
 
 Please see the [Community](https://forensics.wiki/community) page if you would like to contribute.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Forensics Wiki on Github
+# Forensics Wiki on GitHub
 
-The Forensics Wiki is an open source website providing information related to digital forensics. The articles on the website cover a wide range of information from <a href="https://forensics.wiki/tags/#tools">tools</a> used during investigations to <a href="https://forensics.wiki/tags/#papers">papers</a>, <a href="https://forensics.wiki/tags/#people">people</a>, and <a href="https://forensics.wiki/tags/#organization">organizations</a> that contribute to the field.  
+The Forensics Wiki is an open source website providing information related to digital forensics. The articles in the wiki cover a wide range of information from [tools used during investigations](https://forensics.wiki/tags/#tools) to [papers](https://forensics.wiki/tags/#papers), [people](https://forensics.wiki/tags/#people), and [organizations](https://forensics.wiki/tags/#organization) that contribute to the field.
 
 The Forensics Wiki has transitioned to a new domain and platform; read more about it at [Transitioning Forensics Wiki to GitHub](https://osdfir.blogspot.com/2022/11/transitioning-forensics-wiki-to-github.html). You can view the new site at [https://forensics.wiki/](https://forensics.wiki/).
 
-Please see the community page if you would like to [contribute](https://forensics.wiki/community).
+Please see the [Community](https://forensics.wiki/community) page if you would like to contribute.


### PR DESCRIPTION
The README of this repo reads as forward-looking from a historical point, and is very confusing when trying to figure out if this wiki is related to the now-dead MediaWiki wikis. 

This improves the context. 